### PR TITLE
Updated triggers.md with timestamp in milliseconds

### DIFF
--- a/docs/react-native/docs/triggers.md
+++ b/docs/react-native/docs/triggers.md
@@ -122,7 +122,7 @@ import notifee, { TimestampTrigger, TriggerType, TimeUnit } from '@notifee/react
 
 const trigger: TimestampTrigger = {
   type: TriggerType.TIMESTAMP,
-  timestamp: Date.now() + 10800, // fire in 3 hours
+  timestamp: Date.now() + 1000 * 60 * 60 * 3, // fire in 3 hours
   repeatFrequency: RepeatFrequency.WEEKLY, // repeat once a week
 };
 ```


### PR DESCRIPTION
I've updated this doc to reflect correct trigger timestamp from commented description ("fire in 3 hours") as it has to be in milliseconds not in seconds (10800).